### PR TITLE
Draw polygon and get events within

### DIFF
--- a/src/backend/src/controllers/eventController.js
+++ b/src/backend/src/controllers/eventController.js
@@ -216,7 +216,7 @@ exports.unlikeEvent = async (req, res) => {
   }
 };
 
-exports.queryEventsInPolygon = async (req, res) => {
+exports.getEventsWithinPolygon = async (req, res) => {
   const { polygon } = req.body; // GeoJSON Polygon
   if (!polygon || polygon.type !== "Polygon") {
     return res.status(400).json({ error: "Invalid polygon" });

--- a/src/backend/src/controllers/eventController.js
+++ b/src/backend/src/controllers/eventController.js
@@ -232,7 +232,6 @@ exports.getEventsWithinPolygon = async (req, res) => {
     `);
     res.json(events);
   } catch (error) {
-    console.error("Error fetching events within polygon:", error);
     res.status(500).json({ error: "Internal Server Error" });
   }
 };

--- a/src/backend/src/controllers/eventController.js
+++ b/src/backend/src/controllers/eventController.js
@@ -223,15 +223,16 @@ exports.getEventsWithinPolygon = async (req, res) => {
   }
   try {
     const events = await prisma.$queryRawUnsafe(`
-      SELECT *
+      SELECT id, "eventId", "streetAddress", ST_AsText(location) AS location
       FROM event_locations
       WHERE ST_Contains(
         ST_GeomFromGeoJSON('${JSON.stringify(polygon)}'),
         location
-    )
+      )
     `);
     res.json(events);
   } catch (error) {
+    console.error("Error fetching events within polygon:", error);
     res.status(500).json({ error: "Internal Server Error" });
   }
 };

--- a/src/backend/src/controllers/eventController.js
+++ b/src/backend/src/controllers/eventController.js
@@ -215,3 +215,23 @@ exports.unlikeEvent = async (req, res) => {
     res.status(500).json({ error: "Internal Server Error" });
   }
 };
+
+exports.queryEventsInPolygon = async (req, res) => {
+  const { polygon } = req.body; // GeoJSON Polygon
+  if (!polygon || polygon.type !== "Polygon") {
+    return res.status(400).json({ error: "Invalid polygon" });
+  }
+  try {
+    const events = await prisma.$queryRawUnsafe(`
+      SELECT *
+      FROM event_locations
+      WHERE ST_Contains(
+        ST_GeomFromGeoJSON('${JSON.stringify(polygon)}'),
+        location
+    )
+    `);
+    res.json(events);
+  } catch (error) {
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+};

--- a/src/backend/src/routes/eventRoutes.js
+++ b/src/backend/src/routes/eventRoutes.js
@@ -8,6 +8,7 @@ const {
   getEventUserLikes,
   likeEvent,
   unlikeEvent,
+  getEventsWithinPolygon,
 } = require("../controllers/eventController");
 
 const router = express.Router();
@@ -18,6 +19,7 @@ router.get("/:id", getEventById);
 router.post("/", createEvent);
 router.put("/:id", updateEvent);
 router.delete("/:id", deleteEvent);
+router.post("/within-polygon", getEventsWithinPolygon);
 
 // Likes
 router.get("/:id/likes", getEventUserLikes);

--- a/src/frontend/frontend/src/App.jsx
+++ b/src/frontend/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import WithAuth from "./components/WithAuth/WithAuth";
 import CreateEventPage from "./components/CreateEventPage/CreateEventPage";
 import ViewEventPage from "./components/ViewEventPage/ViewEventPage";
 import ViewUserPage from "./components/ViewUserPage/ViewUserPage";
+import MapPlan from "./components/MapPlanPage/MapPlan";
 
 function App() {
   return (
@@ -64,6 +65,14 @@ function App() {
           element={
             <WithAuth>
               <ViewUserPage />
+            </WithAuth>
+          }
+        />
+        <Route
+          path="/plan"
+          element={
+            <WithAuth>
+              <MapPlan />
             </WithAuth>
           }
         />

--- a/src/frontend/frontend/src/api.js
+++ b/src/frontend/frontend/src/api.js
@@ -351,7 +351,7 @@ export async function eventsWithinPolygon(coords){
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify(geojson),
+    body: JSON.stringify({polygon: geojson}),
     credentials: "include",
   });
   const response = await res.json();

--- a/src/frontend/frontend/src/api.js
+++ b/src/frontend/frontend/src/api.js
@@ -340,3 +340,23 @@ export async function getSuggestedUsers(userId) {
   }
   return response;
 }
+
+export async function eventsWithinPolygon(coords){
+  const geojson = {
+          type: "Polygon",
+          coordinates: [coords.map(coord => [coord.lng, coord.lat])]
+        };
+  const res = await fetch(`${URL}/events/within-polygon`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(geojson),
+    credentials: "include",
+  });
+  const response = await res.json();
+  if (!res.ok) {
+    throw new Error(response.error || "Failed to fetch events within polygon");
+  }
+  return response;
+}

--- a/src/frontend/frontend/src/components/MapPlanPage/DrawingManager.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/DrawingManager.jsx
@@ -1,0 +1,34 @@
+import { useMap, useMapsLibrary } from '@vis.gl/react-google-maps';
+import { useEffect, useState } from 'react';
+
+export function DrawingManager({ initialValue = null }) {
+  const map = useMap();
+  const drawing = useMapsLibrary('drawing');
+  const [drawingManager, setDrawingManager] = useState<google.maps.drawing.DrawingManager>;
+
+  useEffect(() => {
+    if (!map || !drawing) return;
+
+    const newDrawingManager = new drawing.DrawingManager({
+      map,
+      drawingMode: null,
+      drawingControl: true,
+      drawingControlOptions: {
+        position: window.google.maps.ControlPosition.TOP_CENTER,
+        drawingModes: [
+          window.google.maps.drawing.OverlayType.POLYGON,
+        ]
+      },
+      polygonOptions: { editable: true, draggable: true },
+      
+    });
+
+    setDrawingManager(newDrawingManager);
+
+    return () => {
+      newDrawingManager.setMap(null);
+    };
+  }, [map, drawing]);
+
+  return drawingManager;
+}

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.css
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.css
@@ -1,0 +1,3 @@
+.map-plan-page{
+    height: 80vh;
+}

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -1,0 +1,17 @@
+/**
+ * 
+ */
+
+import Layout from "../Layout/Layout";
+import MapWithDrawing from "./MapWithDrawing";
+
+export default function MapPlan() {
+    return (
+        <Layout>
+        <div className="map-plan-page">
+            <h1>Map Plan Page</h1>
+                <MapWithDrawing />
+        </div>
+        </Layout>
+    );
+    }

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -3,6 +3,7 @@
  * This component renders a map with drawing capabilities using the @vis.gl/react-google-maps library
  * It requires a Google Maps API key to function.
  * The map allows users to draw polygons and view them on the map.
+ * It also fetches events within the drawn polygon and displays them in a list.
  * 
  * @component
  * @example
@@ -10,6 +11,7 @@
  * @returns {JSX.Element} The rendered MapPlan component.
  */
 
+import React, { useEffect, useState } from "react";
 import Layout from "../Layout/Layout";
 import MapWithDrawing from "./MapWithDrawing";
 import "./MapPlan.css"
@@ -17,14 +19,21 @@ const MAPS_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 import { APIProvider } from "@vis.gl/react-google-maps";
 
 
+
 export default function MapPlan() {
+  const [eventsInPoly, setEventsInPoly] = useState([]);
   return (
     <Layout>
       <div className="map-plan-page">
         <h1>Map Plan Page</h1>
     <APIProvider apiKey={MAPS_KEY}>
-          <MapWithDrawing />
+          <MapWithDrawing onEventsFound={setEventsInPoly} />
           </APIProvider>
+          <ul>
+            {eventsInPoly.map(event => (
+            <li key={event.id}>{event.id}</li>
+          ))}
+          </ul>
       </div>
     </Layout>
   );

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -31,7 +31,7 @@ export default function MapPlan() {
           </APIProvider>
           <ul>
             {eventsInPoly.map(event => (
-            <li key={event.id}>{event.id}</li>
+            <li key={event.id}> Event ID: {event.id}</li>
           ))}
           </ul>
       </div>

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -1,17 +1,18 @@
 /**
- * 
+ *
  */
 
 import Layout from "../Layout/Layout";
 import MapWithDrawing from "./MapWithDrawing";
+import "./MapPlan.css"
 
 export default function MapPlan() {
-    return (
-        <Layout>
-        <div className="map-plan-page">
-            <h1>Map Plan Page</h1>
-                <MapWithDrawing />
-        </div>
-        </Layout>
-    );
-    }
+  return (
+    <Layout>
+      <div className="map-plan-page">
+        <h1>Map Plan Page</h1>
+          <MapWithDrawing />
+      </div>
+    </Layout>
+  );
+}

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -1,17 +1,30 @@
 /**
- *
+ * MapPlan.jsx
+ * This component renders a map with drawing capabilities using the @vis.gl/react-google-maps library
+ * It requires a Google Maps API key to function.
+ * The map allows users to draw polygons and view them on the map.
+ * 
+ * @component
+ * @example
+ * <MapPlan />
+ * @returns {JSX.Element} The rendered MapPlan component.
  */
 
 import Layout from "../Layout/Layout";
 import MapWithDrawing from "./MapWithDrawing";
 import "./MapPlan.css"
+const MAPS_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+import { APIProvider } from "@vis.gl/react-google-maps";
+
 
 export default function MapPlan() {
   return (
     <Layout>
       <div className="map-plan-page">
         <h1>Map Plan Page</h1>
+    <APIProvider apiKey={MAPS_KEY}>
           <MapWithDrawing />
+          </APIProvider>
       </div>
     </Layout>
   );

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -1,33 +1,35 @@
-import React, { useEffect, useRef } from "react";
-const MAPS_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+import React from 'react';
+import { ControlPosition, Map, MapControl } from '@vis.gl/react-google-maps';
 
-export default function MapWithDrawing() {
-  const ref = useRef(null);
+import { DrawingManager } from './DrawingManager';
+import { UndoRedoControl } from './undo-redo-control';
+import ControlPanel from './control-panel';
 
-  useEffect(() => {
-    const script = document.createElement("script");
-    script.src = `https://maps.googleapis.com/maps/api/js?key=${MAPS_KEY}&libraries=drawing`;
-    script.async = true;
-    script.onload = () => {
-      const map = new window.google.maps.Map(ref.current, {
-        center: { lat: 37.4845, lng: -122.1478 },
-        zoom: 10,
-      });
-      const drawingManager = new window.google.maps.drawing.DrawingManager({
-        drawingMode: null,
-        drawingControl: true,
-        drawingControlOptions: {
-          position: window.google.maps.ControlPosition.TOP_CENTER,
-          drawingModes: [
-            window.google.maps.drawing.OverlayType.POLYGON,
-            window.google.maps.drawing.OverlayType.CIRCLE,
-          ],
-        },
-      });
-      drawingManager.setMap(map);
-    };
-    document.body.appendChild(script);
-  }, []);
+const DrawingExample = () => {
+  // If you need to access the DrawingManager instance, you can use a ref or state.
+  // For now, we'll just render it to enable drawing on the map.
 
-  return <div ref={ref} style={{ width: "80vw", height: "80vh" }} />;
-}
+  return (
+    <>
+      <Map
+        defaultZoom={3}
+        defaultCenter={{ lat: 22.54992, lng: 0 }}
+        gestureHandling={'greedy'}
+        disableDefaultUI={true}
+      >
+        {/* DrawingManager must be a child of Map to access the map context */}
+        <DrawingManager />
+      </Map>
+
+      <ControlPanel />
+
+      <MapControl position={ControlPosition.TOP_CENTER}>
+        {/* If UndoRedoControl needs the drawingManager, 
+            you can lift state up and pass it down as a prop */}
+        <UndoRedoControl />
+      </MapControl>
+    </>
+  );
+};
+
+export default DrawingExample;

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -37,8 +37,8 @@ const MapWithDrawing = () => {
 
   return (
     <Map
-      defaultZoom={3}
-      defaultCenter={{ lat: 22.54992, lng: 0 }}
+      defaultZoom={10}
+      defaultCenter={{ lat: 37.4845, lng: -122.1478 }}
       gestureHandling={'greedy'}
       disableDefaultUI={true}
     />

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -8,10 +8,10 @@ export default function MapWithDrawing({ events = [], currentLocation }) {
   const drawingManagerRef = useRef(null);
   const [markers, setMarkers] = useState(events);
 
-  const onMapLoad = useCallback((mapInstance) => {
-    mapRef.current = mapInstance.target;
+  const onMapLoad = useCallback((map) => {
+    mapRef.current = map;
 
-    drawingManagerRef.current = new google.maps.drawing.DrawingManager({
+    const dm = new google.maps.drawing.DrawingManager({
       drawingMode: google.maps.drawing.OverlayType.POLYGON,
       drawingControl: true,
       drawingControlOptions: {
@@ -27,13 +27,10 @@ export default function MapWithDrawing({ events = [], currentLocation }) {
         draggable: false,
       },
     });
-    drawingManagerRef.current.setMap(mapRef.current);
+    dm.setMap(map);
+    drawingManagerRef.current = dm;
 
-    google.maps.event.addListener(
-      drawingManagerRef.current,
-      "polygoncomplete",
-      handlePolygonComplete
-    );
+    google.maps.event.addListener(dm, "polygoncomplete", handlePolygonComplete);
   }, []);
 
   const handlePolygonComplete = async (polygon) => {
@@ -63,15 +60,11 @@ export default function MapWithDrawing({ events = [], currentLocation }) {
     <APIProvider apiKey={MAPS_KEY} libraries={["drawing"]}>
       <div style={{ width: "100%", height: "100%" }}>
         <Map
-        onLoad={onMapLoad}
-          defaultCenter={
-            currentLocation
-              ? { lat: currentLocation.lat, lng: currentLocation.lng }
-              : { lat: 37.4845, lng: -122.1478 }
-          }
+          onLoad={onMapLoad}
+          defaultCenter={currentLocation || { lat: 37.4845, lng: -122.1478 }}
           defaultZoom={10}
           gestureHandling={"greedy"}
-          style={{ width: "100%", height: "100%" }}
+          style={{ width: "80%", height: "80%" }}
           options={{
             disableDefaultUI: true,
           }}

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -8,8 +8,8 @@ export default function MapWithDrawing({ events = [], currentLocation }) {
   const drawingManagerRef = useRef(null);
   const [markers, setMarkers] = useState(events);
 
-  const onMapLoad = useCallback((event) => {
-    mapRef.current = event.target;
+  const onMapLoad = useCallback((mapInstance) => {
+    mapRef.current = mapInstance.target;
 
     drawingManagerRef.current = new google.maps.drawing.DrawingManager({
       drawingMode: google.maps.drawing.OverlayType.POLYGON,
@@ -63,6 +63,7 @@ export default function MapWithDrawing({ events = [], currentLocation }) {
     <APIProvider apiKey={MAPS_KEY} libraries={["drawing"]}>
       <div style={{ width: "100%", height: "100%" }}>
         <Map
+        onLoad={onMapLoad}
           defaultCenter={
             currentLocation
               ? { lat: currentLocation.lat, lng: currentLocation.lng }
@@ -72,11 +73,7 @@ export default function MapWithDrawing({ events = [], currentLocation }) {
           gestureHandling={"greedy"}
           style={{ width: "100%", height: "100%" }}
           options={{
-            styles: [
-              {
-                disableDefaultUI: true,
-              },
-            ],
+            disableDefaultUI: true,
           }}
         >
           {/* Current location marker */}

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -1,14 +1,39 @@
-import React, {useRef, useEffect, useState, useCallback} from "react";
-import{
-    APIProvider, Map, AdvancedMarker,
-} from "@vis.gl/react-google-maps";
+import React, { useRef, useEffect, useState, useCallback } from "react";
+import { APIProvider, Map, AdvancedMarker } from "@vis.gl/react-google-maps";
 
 const MAPS_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 
-export default function MapComponent({events = [], currentLocation}) {
-    const mapRef = useRef(null);
-    const drawingManagerRef = useRef(null);
-    const [markers, setMarkers] = useState(events);
-    <>Map</>
+export default function MapComponent({ events = [], currentLocation }) {
+  const mapRef = useRef(null);
+  const drawingManagerRef = useRef(null);
+  const [markers, setMarkers] = useState(events);
 
+  const onMapLoad = useCallback((event) => {
+    mapRef.current = event.target;
+
+    drawingManagerRef.current = new google.maps.drawing.DrawingManager({
+      drawingMode: google.maps.drawing.Overlaytyp.POLYGON,
+      drawingControl: true,
+      drawingControlOptions: {
+        position: google.maps.ControlPosition.TOP_CENTER,
+        drawingModes: [google.maps.drawing.OverlayType.POLYGON],
+      },
+      polygonOptions: {
+        fillColor: "#2196F3",
+        fillOpacity: 0.2,
+        strokeWeight: 2,
+        clickable: false,
+        editable: false,
+        draggable: false,
+      },
+    });
+    drawingManagerRef.current.setMap(mapRef.current);
+
+    google.maps.event.addListener(
+      drawingManagerRef.current,
+      "polygoncomplete",
+      handlePolygonComplete
+    );
+  }, []);
+  
 }

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -1,98 +1,33 @@
-import React, { useRef, useEffect, useState, useCallback } from "react";
-import { APIProvider, Map, AdvancedMarker } from "@vis.gl/react-google-maps";
-
+import React, { useEffect, useRef } from "react";
 const MAPS_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 
-export default function MapWithDrawing({ events = [], currentLocation }) {
-  const mapRef = useRef(null);
-  const drawingManagerRef = useRef(null);
-  const [markers, setMarkers] = useState(events);
+export default function MapWithDrawing() {
+  const ref = useRef(null);
 
-  const onMapLoad = useCallback((map) => {
-    mapRef.current = map;
-
-    const dm = new google.maps.drawing.DrawingManager({
-      drawingMode: google.maps.drawing.OverlayType.POLYGON,
-      drawingControl: true,
-      drawingControlOptions: {
-        position: google.maps.ControlPosition.TOP_CENTER,
-        drawingModes: [google.maps.drawing.OverlayType.POLYGON],
-      },
-      polygonOptions: {
-        fillColor: "#2196F3",
-        fillOpacity: 0.2,
-        strokeWeight: 2,
-        clickable: false,
-        editable: false,
-        draggable: false,
-      },
-    });
-    dm.setMap(map);
-    drawingManagerRef.current = dm;
-
-    google.maps.event.addListener(dm, "polygoncomplete", handlePolygonComplete);
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${MAPS_KEY}&libraries=drawing`;
+    script.async = true;
+    script.onload = () => {
+      const map = new window.google.maps.Map(ref.current, {
+        center: { lat: 37.4845, lng: -122.1478 },
+        zoom: 10,
+      });
+      const drawingManager = new window.google.maps.drawing.DrawingManager({
+        drawingMode: null,
+        drawingControl: true,
+        drawingControlOptions: {
+          position: window.google.maps.ControlPosition.TOP_CENTER,
+          drawingModes: [
+            window.google.maps.drawing.OverlayType.POLYGON,
+            window.google.maps.drawing.OverlayType.CIRCLE,
+          ],
+        },
+      });
+      drawingManager.setMap(map);
+    };
+    document.body.appendChild(script);
   }, []);
 
-  const handlePolygonComplete = async (polygon) => {
-    const path = polygon
-      .getPath()
-      .getArray()
-      .map((latLng) => [latLng.lat(), latLng.lng()]);
-    if (
-      (path.length > 0 && path[0][0] !== path[path.length - 1][0]) ||
-      path[0][1] !== path[path.length - 1][1]
-    ) {
-      path.push(path[0]);
-    }
-
-    const geojson = {
-      type: "Polygon",
-      coordinates: [path],
-    };
-
-    // send to backend
-    // addPolygon(geojson)
-    // get events in polygon
-    polygon.setMap(null);
-  };
-
-  return (
-    <APIProvider apiKey={MAPS_KEY} libraries={["drawing"]}>
-      <div style={{ width: "100%", height: "100%" }}>
-        <Map
-          onLoad={onMapLoad}
-          defaultCenter={currentLocation || { lat: 37.4845, lng: -122.1478 }}
-          defaultZoom={10}
-          gestureHandling={"greedy"}
-          style={{ width: "80%", height: "80%" }}
-          options={{
-            disableDefaultUI: true,
-          }}
-        >
-          {/* Current location marker */}
-          {currentLocation && (
-            <AdvancedMarker
-              position={{
-                lat: currentLocation.lat,
-                lng: currentLocation.lng,
-              }}
-              title="Your Location"
-            />
-          )}
-
-          {/* Event markers */}
-          {markers.map((event) => (
-            <AdvancedMarker
-              key={event.id}
-              position={{
-                lat: ev.location.latitude,
-                lng: ev.location.longitude,
-              }}
-              title={ev.title}
-            />
-          ))}
-        </Map>
-      </div>
-    </APIProvider>
-  );
+  return <div ref={ref} style={{ width: "80vw", height: "80vh" }} />;
 }

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -1,0 +1,14 @@
+import React, {useRef, useEffect, useState, useCallback} from "react";
+import{
+    APIProvider, Map, AdvancedMarker,
+} from "@vis.gl/react-google-maps";
+
+const MAPS_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+
+export default function MapComponent({events = [], currentLocation}) {
+    const mapRef = useRef(null);
+    const drawingManagerRef = useRef(null);
+    const [markers, setMarkers] = useState(events);
+    <>Map</>
+
+}

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -1,35 +1,48 @@
-import React from 'react';
-import { ControlPosition, Map, MapControl } from '@vis.gl/react-google-maps';
+/**
+ * MapWithDrawing.jsx
+ * This component renders a Google Map with drawing capabilities using the @vis.gl/react-google-maps library.
+ * It allows users to draw polygons on the map and logs the coordinates of the drawn polygons.
+ * 
+ * @component
+ * @example
+ * <MapWithDrawing />
+ * @returns {JSX.Element} The rendered MapWithDrawing component.
+ */
+import React, { useEffect } from 'react';
+import { Map } from '@vis.gl/react-google-maps';
+import { useDrawingManager } from './useDrawingManager';
 
-import { DrawingManager } from './DrawingManager';
-import { UndoRedoControl } from './undo-redo-control';
-import ControlPanel from './control-panel';
+const MapWithDrawing = () => {
+  const drawingManager = useDrawingManager();
 
-const DrawingExample = () => {
-  // If you need to access the DrawingManager instance, you can use a ref or state.
-  // For now, we'll just render it to enable drawing on the map.
+  useEffect(() => {
+    if (!drawingManager) return;
+
+    const listener = drawingManager.addListener('overlaycomplete', (e) => {
+      const poly = e.overlay;
+      if (poly && poly.getPath) {
+        const coords = poly.getPath().getArray().map(point => ({
+          lat: point.lat(),
+          lng: point.lng()
+        }));
+        // Log the coordinates of the drawn polygon - just for demonstrating working functionality
+        console.log(coords);
+      }
+    });
+
+    return () => {
+      if (listener) listener.remove();
+    };
+  }, [drawingManager]);
 
   return (
-    <>
-      <Map
-        defaultZoom={3}
-        defaultCenter={{ lat: 22.54992, lng: 0 }}
-        gestureHandling={'greedy'}
-        disableDefaultUI={true}
-      >
-        {/* DrawingManager must be a child of Map to access the map context */}
-        <DrawingManager />
-      </Map>
-
-      <ControlPanel />
-
-      <MapControl position={ControlPosition.TOP_CENTER}>
-        {/* If UndoRedoControl needs the drawingManager, 
-            you can lift state up and pass it down as a prop */}
-        <UndoRedoControl />
-      </MapControl>
-    </>
+    <Map
+      defaultZoom={3}
+      defaultCenter={{ lat: 22.54992, lng: 0 }}
+      gestureHandling={'greedy'}
+      disableDefaultUI={true}
+    />
   );
 };
 
-export default DrawingExample;
+export default MapWithDrawing;

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -39,8 +39,6 @@ const MapWithDrawing = ({ onEventsFound }) => {
               lat: point.lat(),
               lng: point.lng(),
             }));
-          // Log the coordinates of the drawn polygon - just for demonstrating working functionality
-          console.log(coords);
           try {
             const events = await eventsWithinPolygon(coords);
             if (onEventsFound) {

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -11,6 +11,7 @@
 import React, { useEffect } from 'react';
 import { Map } from '@vis.gl/react-google-maps';
 import { useDrawingManager } from './useDrawingManager';
+import {eventsWithinPolygon} from '../../api'
 
 const MapWithDrawing = () => {
   const drawingManager = useDrawingManager();
@@ -18,7 +19,7 @@ const MapWithDrawing = () => {
   useEffect(() => {
     if (!drawingManager) return;
 
-    const listener = drawingManager.addListener('overlaycomplete', (e) => {
+    const listener = drawingManager.addListener('overlaycomplete', async (e) => {
       const poly = e.overlay;
       if (poly && poly.getPath) {
         const coords = poly.getPath().getArray().map(point => ({
@@ -27,6 +28,12 @@ const MapWithDrawing = () => {
         }));
         // Log the coordinates of the drawn polygon - just for demonstrating working functionality
         console.log(coords);
+        try {
+          const events = await eventsWithinPolygon(coords);
+          console.log("Events within polygon:", events);
+        } catch (err) {
+          console.error("Failed to fetch events within polygon:", err);
+        }
       }
     });
 

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -12,7 +12,7 @@ export default function MapComponent({ events = [], currentLocation }) {
     mapRef.current = event.target;
 
     drawingManagerRef.current = new google.maps.drawing.DrawingManager({
-      drawingMode: google.maps.drawing.Overlaytyp.POLYGON,
+      drawingMode: google.maps.drawing.OverlayType.POLYGON,
       drawingControl: true,
       drawingControlOptions: {
         position: google.maps.ControlPosition.TOP_CENTER,
@@ -35,5 +35,74 @@ export default function MapComponent({ events = [], currentLocation }) {
       handlePolygonComplete
     );
   }, []);
-  
+
+  const handlePolygonComplete = async (polygon) => {
+    const path = polygon
+      .getPath()
+      .getArray()
+      .map((latLng) => [latLng.lat(), latLng.lng()]);
+    if (
+      (path.length > 0 && path[0][0] !== path[path.length - 1][0]) ||
+      path[0][1] !== path[path.length - 1][1]
+    ) {
+      path.push(path[0]);
+    }
+
+    const geojson = {
+      type: "Polygon",
+      coordinates: [path],
+    };
+
+    // send to backend
+    // addPolygon(geojson)
+    // get events in polygon
+    polygon.setMap(null);
+  };
+
+  return (
+    <APIProvider apiKey={MAPS_KEY} libraries={["drawing"]}>
+      <div style={{ width: "100%", height: "100%" }}>
+        <Map
+          defaultCenter={
+            currentLocation
+              ? { lat: currentLocation.lat, lng: currentLocation.lng }
+              : { lat: 37.4845, lng: -122.1478 }
+          }
+          defaultZoom={10}
+          gestureHandling={"greedy"}
+          style={{ width: "100%", height: "100%" }}
+          options={{
+            styles: [
+              {
+                disableDefaultUI: true,
+              },
+            ],
+          }}
+        >
+          {/* Current location marker */}
+          {currentLocation && (
+            <AdvancedMarker
+              position={{
+                lat: currentLocation.lat,
+                lng: currentLocation.lng,
+              }}
+              title="Your Location"
+            />
+          )}
+
+          {/* Event markers */}
+          {markers.map((event) => (
+            <AdvancedMarker
+              key={event.id}
+              position={{
+                lat: ev.location.latitude,
+                lng: ev.location.longitude,
+              }}
+              title={ev.title}
+            />
+          ))}
+        </Map>
+      </div>
+    </APIProvider>
+  );
 }

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -3,7 +3,7 @@ import { APIProvider, Map, AdvancedMarker } from "@vis.gl/react-google-maps";
 
 const MAPS_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 
-export default function MapComponent({ events = [], currentLocation }) {
+export default function MapWithDrawing({ events = [], currentLocation }) {
   const mapRef = useRef(null);
   const drawingManagerRef = useRef(null);
   const [markers, setMarkers] = useState(events);

--- a/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapWithDrawing.jsx
@@ -1,52 +1,68 @@
 /**
  * MapWithDrawing.jsx
  * This component renders a Google Map with drawing capabilities using the @vis.gl/react-google-maps library.
- * It allows users to draw polygons on the map and logs the coordinates of the drawn polygons.
+ * It allows users to draw polygons on the map and fetches events within the drawn polygon.
+ * The component listens for the "overlaycomplete" event from the DrawingManager to get the coordinates
+ * of the drawn polygon and fetches events within that polygon using the `eventsWithinPolygon`
+ * API function.
+ * It also accepts a callback function `onEventsFound` to handle the fetched events.
  * 
+ *
  * @component
+ * @param {Object} props - The properties passed to the component.
+ * @param {Function} props.onEventsFound - Callback function to handle events found within the
  * @example
  * <MapWithDrawing />
  * @returns {JSX.Element} The rendered MapWithDrawing component.
  */
-import React, { useEffect } from 'react';
-import { Map } from '@vis.gl/react-google-maps';
-import { useDrawingManager } from './useDrawingManager';
-import {eventsWithinPolygon} from '../../api'
 
-const MapWithDrawing = () => {
+import React, { useEffect, useState } from "react";
+import { Map } from "@vis.gl/react-google-maps";
+import { useDrawingManager } from "./useDrawingManager";
+import { eventsWithinPolygon } from "../../api";
+
+const MapWithDrawing = ({ onEventsFound }) => {
   const drawingManager = useDrawingManager();
 
   useEffect(() => {
     if (!drawingManager) return;
 
-    const listener = drawingManager.addListener('overlaycomplete', async (e) => {
-      const poly = e.overlay;
-      if (poly && poly.getPath) {
-        const coords = poly.getPath().getArray().map(point => ({
-          lat: point.lat(),
-          lng: point.lng()
-        }));
-        // Log the coordinates of the drawn polygon - just for demonstrating working functionality
-        console.log(coords);
-        try {
-          const events = await eventsWithinPolygon(coords);
-          console.log("Events within polygon:", events);
-        } catch (err) {
-          console.error("Failed to fetch events within polygon:", err);
+    const listener = drawingManager.addListener(
+      "overlaycomplete",
+      async (e) => {
+        const poly = e.overlay;
+        if (poly && poly.getPath) {
+          const coords = poly
+            .getPath()
+            .getArray()
+            .map((point) => ({
+              lat: point.lat(),
+              lng: point.lng(),
+            }));
+          // Log the coordinates of the drawn polygon - just for demonstrating working functionality
+          console.log(coords);
+          try {
+            const events = await eventsWithinPolygon(coords);
+            if (onEventsFound) {
+              onEventsFound(events);
+            }
+          } catch (err) {
+            // Handle error appropriately
+          }
         }
       }
-    });
+    );
 
     return () => {
       if (listener) listener.remove();
     };
-  }, [drawingManager]);
+  }, [drawingManager, onEventsFound]);
 
   return (
     <Map
       defaultZoom={10}
       defaultCenter={{ lat: 37.4845, lng: -122.1478 }}
-      gestureHandling={'greedy'}
+      gestureHandling={"greedy"}
       disableDefaultUI={true}
     />
   );

--- a/src/frontend/frontend/src/components/MapPlanPage/useDrawingManager.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/useDrawingManager.jsx
@@ -1,10 +1,20 @@
+/**
+ * useDrawingManager.jsx
+ * This custom hook initializes a Google Maps DrawingManager to allow users to draw polygons on the map.
+ * It uses the @vis.gl/react-google-maps library to integrate with Google Maps.
+ * The DrawingManager provides a UI for drawing shapes and allows for editing and dragging of polygons.
+ * 
+ * @hook
+ * @example
+ * const drawingManager = useDrawingManager();
+ */
 import { useMap, useMapsLibrary } from '@vis.gl/react-google-maps';
 import { useEffect, useState } from 'react';
 
-export function DrawingManager({ initialValue = null }) {
+export function useDrawingManager() {
   const map = useMap();
   const drawing = useMapsLibrary('drawing');
-  const [drawingManager, setDrawingManager] = useState<google.maps.drawing.DrawingManager>;
+  const [drawingManager, setDrawingManager] = useState(null);
 
   useEffect(() => {
     if (!map || !drawing) return;
@@ -20,7 +30,6 @@ export function DrawingManager({ initialValue = null }) {
         ]
       },
       polygonOptions: { editable: true, draggable: true },
-      
     });
 
     setDrawingManager(newDrawingManager);

--- a/src/frontend/frontend/src/components/NavHeader/NavHeader.jsx
+++ b/src/frontend/frontend/src/components/NavHeader/NavHeader.jsx
@@ -31,6 +31,11 @@ export default function NavHeader() {
             </NavigationMenuLink>
           </NavigationMenuItem>
           <NavigationMenuItem>
+          <NavigationMenuLink asChild>
+            <Link to="/plan">Plan</Link>
+          </NavigationMenuLink>
+          </NavigationMenuItem>
+          <NavigationMenuItem>
             <NavigationMenuLink asChild>
               <Link to="/profile">Profile</Link>
             </NavigationMenuLink>


### PR DESCRIPTION
## Description

This PR creates functionality for the user to draw a polygon on the map, and display all events in that polygon. It adds endpoints for spatial querying and a frontend component that allows for users to draw polygons and view the resulting events. I created a map component that allows drawing, and upon creation of the polygon, queries my backend with that polygon.

Next steps will be to allow the user to filter the events by time, and create routes between the events for TC2.

## Milestones

This works towards TC2, and allows for more planning featuring to be built on the base component in this PR.

## Resources

For my map drawing feature, I used [Google's Drawing API](https://developers.google.com/maps/documentation/javascript/examples/drawing-tools).

## Test Plan
Here is an image of a drawn polygon with the event ids contained in that polygon displayed beneath it.
<img width="1498" height="1388" alt="Screenshot 2025-07-10 at 10 54 57 AM" src="https://github.com/user-attachments/assets/aa45c1e8-a94c-46d2-99fc-4a0e42652218" />
