### PR TITLE
Adds tag and duration to generation

### DIFF
--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -501,7 +501,7 @@ exports.createPlan = async (req, res) => {
 
   try {
     const ownerId = req.params.id;
-    const { title, eventIds, routeData } = req.body;
+    const { title, eventIds, routeData, durations } = req.body;
     const { data, error } = await supabase
       .from("plans")
       .insert([
@@ -510,6 +510,7 @@ exports.createPlan = async (req, res) => {
           title,
           event_ids: eventIds,
           route_data: routeData,
+          durations: durations
         },
       ])
       .select()

--- a/src/frontend/frontend/src/api.js
+++ b/src/frontend/frontend/src/api.js
@@ -391,14 +391,14 @@ export async function meUrl(path){
   return `${URL}/users/${me}${path}`;
 }
 
-export async function createPlan( {title, eventIds, routeData}){
+export async function createPlan( {title, eventIds, routeData, durations}){
   const url = await meUrl("/plans");
   const res = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ title, eventIds, routeData }),
+    body: JSON.stringify({ title, eventIds, routeData, durations }),
     credentials: "include",
   });
   const response = await res.json();

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -225,7 +225,7 @@ export default function MapPlan() {
       alert("Please select a time period for the events.");
       return;
     }
-    durations = {};
+    let durations = {};
 
     const eventsToGenerate = filteredEvents
       .slice() // copy array

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -358,7 +358,7 @@ export default function MapPlan() {
         >
           Choose Events
         </Button>
-        <Button onClick={generateEventPlan}>Generate Events</Button>
+        <Button onClick={() => setIsTagDialogOpen(true)}>Generate Events</Button>
         <Dialog open={isTagDialogOpen} onOpenChange={setIsTagDialogOpen}>
           <DialogContent className="sm:max-w-[400px] bg-[var(--card)] text-[var(--card-foreground)] border border-[var(--border)] rounded-xl shadow">
             <DialogHeader>
@@ -406,7 +406,7 @@ export default function MapPlan() {
               <Button
                 onClick={() => {
                   setIsTagDialogOpen(false);
-                  generateEventPlanWithTag(preferredTag);
+                  generateEventPlan(preferredTag);
                 }}
                 disabled={availableTags.length === 0}
               >

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -607,7 +607,7 @@ export default function MapPlan() {
                     title: planTitle,
                     eventIds: selectedEventIds,
                     routeData: routeData,
-                    eventDurations: eventDurations,
+                    durations: eventDurations,
                   });
                   setPlanId(plan.id);
                   await inviteUsers(plan.id, selectedFollowers);

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -62,6 +62,7 @@ export default function MapPlan() {
   const [userTagSet, setUserTagSet] = useState(new Set());
   const [isTagDialogOpen, setIsTagDialogOpen] = useState(false);
   const [preferredTag, setPreferredTag] = useState("");
+  const [eventDurations, setEventDurations] = useState({});
 
   const filterStart = startDate ? new Date(startDate) : null;
   const filterEnd = endDate ? new Date(endDate) : null;
@@ -224,6 +225,7 @@ export default function MapPlan() {
       alert("Please select a time period for the events.");
       return;
     }
+    durations = {};
 
     const eventsToGenerate = filteredEvents
       .slice() // copy array
@@ -276,7 +278,10 @@ export default function MapPlan() {
       });
 
       const pick = possibleEvents[0];
+      const isPreferred = preferredTag && (pick.tags || []).some(t=> t.name === preferredTag);
+      const durationMs = (isPreferred ? 90 : 60) * 60 * 1000; // 90 mins if preferred tag, else 60 mins
       picks.push(pick.id);
+      durations[pick.id] = durationMs;
       usedIds.add(pick.id);
 
       curTime = pick.arriveAt + 60 * 60 * 1000; // 1 hour at event
@@ -294,6 +299,7 @@ export default function MapPlan() {
     alert(
       `Generated plan with ${picks.length} events based on your criteria. You can now calculate the route.`
     );
+    setEventDurations(durations);
   };
 
   const handleTempSelectEvent = (eventId) => {
@@ -358,7 +364,9 @@ export default function MapPlan() {
         >
           Choose Events
         </Button>
-        <Button onClick={() => setIsTagDialogOpen(true)}>Generate Events</Button>
+        <Button onClick={() => setIsTagDialogOpen(true)}>
+          Generate Events
+        </Button>
         <Dialog open={isTagDialogOpen} onOpenChange={setIsTagDialogOpen}>
           <DialogContent className="sm:max-w-[400px] bg-[var(--card)] text-[var(--card-foreground)] border border-[var(--border)] rounded-xl shadow">
             <DialogHeader>
@@ -599,6 +607,7 @@ export default function MapPlan() {
                     title: planTitle,
                     eventIds: selectedEventIds,
                     routeData: routeData,
+                    eventDurations: eventDurations,
                   });
                   setPlanId(plan.id);
                   await inviteUsers(plan.id, selectedFollowers);

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -33,7 +33,6 @@ export default function PlanViewer() {
       Promise.all(plan.event_ids.map((id) => getEventById(id)))
         .then(setEvents)
         .catch(() => alert("Failed to load events"));
-        console.log("Events fetched:", events);
     }
   }, [plan]);
 
@@ -73,9 +72,9 @@ export default function PlanViewer() {
       <div className="event-list bg-white rounded-b-xl shadow-inner p-6">
         <h2 className="text-xl font-semibold mb-4">Stops on This Plan</h2>
         <ol className="list-decimal ml-6">
-          {(plan.events || []).map((event, idx) => (
+          {(events || []).map((event, idx) => (
             <li key={event.id || idx} className="mb-2">
-              <div className="font-bold">{event.name}</div>
+              <div className="font-bold">{event.title}</div>
               <div className="text-sm text-gray-600">{event.address}</div>
               {/* Add more event details as needed */}
             </li>

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -81,12 +81,18 @@ export default function PlanViewer() {
       </div>
       <div className="event-list bg-white rounded-b-xl shadow-inner p-6">
         <h2 className="text-xl font-semibold mb-4">Stops on This Plan</h2>
-        <ol className="list-decimal ml-6">
-          {(orderedEvents || []).map((event, idx) => (
-            <li key={event.id || idx} className="mb-2">
-              <div className="font-bold">{event.title}</div>
-            </li>
-          ))}
+         <ol className="list-decimal ml-6">
+          {(orderedEvents || []).map((event, idx) => {
+            const mins = durations && durations[event.id] ? durations[event.id] : 60;
+            return (
+              <li key={event.id || idx} className="mb-2">
+                <div className="font-bold">{event.title}</div>
+                <div className="text-sm text-gray-600">
+                  {mins} minutes
+                </div>
+              </li>
+            );
+          })}
         </ol>
       </div>
     </Layout>

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -59,6 +59,18 @@ export default function PlanViewer() {
           </APIProvider>
         </div>
       </div>
+      <div className="event-list bg-white rounded-b-xl shadow-inner p-6">
+        <h2 className="text-xl font-semibold mb-4">Stops on This Plan</h2>
+        <ol className="list-decimal ml-6">
+          {(plan.events || []).map((event, idx) => (
+            <li key={event.id || idx} className="mb-2">
+              <div className="font-bold">{event.name}</div>
+              <div className="text-sm text-gray-600">{event.address}</div>
+              {/* Add more event details as needed */}
+            </li>
+          ))}
+        </ol>
+      </div>
     </Layout>
   );
 }

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -27,6 +27,8 @@ export default function PlanViewer() {
       .catch(() => alert("Failed to load plan"));
   }, [planId]);
 
+  const durations = plan?.durations || {};
+
   // Fetch events when plan is loaded
   useEffect(() => {
     if (plan && plan.event_ids && plan.event_ids.length > 0) {

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -44,21 +44,37 @@ export default function PlanViewer() {
       return idx.map((i) => events[i]).filter(Boolean);
     }
     return events;
-  }, [plan,events]);
+  }, [plan, events]);
 
   if (!plan) return <div>Loading...</div>;
 
   return (
     <Layout>
       <div className="map-plan-page relative w-full max-w-5xl mx-auto mt-10 bg-[var(--card)] text-[var(--card-foreground)] rounded-xl shadow-lg border border-[var(--border)] overflow-hidden h-auto">
-        {" "}
-        <div
-          className="absolute top-0 left-0 w-full bg-[var(--primary)] bg-opacity-90 text-[var(--primary-foreground)] py-6 text-center z-10 text-2xl font-bold tracking-wide rounded-t-xl shadow"
-          style={{ paddingTop: "4rem" }}
-        >
-          {plan.title || "Plan Title"}
+        <div className="flex w-full bg-[var(--primary)] bg-opacity-90 text-[var(--primary-foreground)] py-6 px-8 z-10 rounded-t-xl shadow items-center justify-between">
+          <div className="text-2xl font-bold tracking-wide flex-1 text-left">
+            {plan.title || "Plan Title"}
+          </div>
+          <div className="flex-1 text-right">
+            <h2 className="text-xl font-semibold mb-2">Stops on This Plan</h2>
+            <ul className="inline-block text-left max-h-48 overflow-y-auto pr-2">
+              {(orderedEvents || []).map((event, idx) => {
+                const mins =
+                  durations && durations[event.id]
+                    ? Math.round(durations[event.id] / 60000)
+                    : 60;
+                return (
+                  <li key={event.id || idx} className="mb-1 flex items-center">
+                    <span className="font-bold mr-2">{idx + 1}.</span>
+                    <span className="font-bold">{event.title}</span>
+                    <span className="ml-2 text-sm">{mins} min</span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
         </div>
-        <div className="h-[75vh] w-full rounded-lg overflow-hidden">
+        <div className="h-[75vh] w-full rounded-b-xl overflow-hidden">
           <APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}>
             <Map
               mapId="4f917a8c04fdd7367b6986a1"
@@ -78,22 +94,6 @@ export default function PlanViewer() {
             </Map>
           </APIProvider>
         </div>
-      </div>
-      <div className="event-list bg-white rounded-b-xl shadow-inner p-6">
-        <h2 className="text-xl font-semibold mb-4">Stops on This Plan</h2>
-         <ol className="list-decimal ml-6">
-          {(orderedEvents || []).map((event, idx) => {
-            const mins = durations && durations[event.id] ? durations[event.id] : 60;
-            return (
-              <li key={event.id || idx} className="mb-2">
-                <div className="font-bold">{event.title}</div>
-                <div className="text-sm text-gray-600">
-                  {mins} minutes
-                </div>
-              </li>
-            );
-          })}
-        </ol>
       </div>
     </Layout>
   );

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -36,6 +36,14 @@ export default function PlanViewer() {
     }
   }, [plan]);
 
+  const orderedEvents = React.useMemo(() => {
+    const idx = plan?.route_data?.optimizedIntermediateWaypointIndex;
+    if (idx && idx.length == events.length) {
+      return idx.map((i) => events[i]).filter(Boolean);
+    }
+    return events;
+  }, [plan,events]);
+
   if (!plan) return <div>Loading...</div>;
 
   return (
@@ -72,11 +80,9 @@ export default function PlanViewer() {
       <div className="event-list bg-white rounded-b-xl shadow-inner p-6">
         <h2 className="text-xl font-semibold mb-4">Stops on This Plan</h2>
         <ol className="list-decimal ml-6">
-          {(events || []).map((event, idx) => (
+          {(orderedEvents || []).map((event, idx) => (
             <li key={event.id || idx} className="mb-2">
               <div className="font-bold">{event.title}</div>
-              <div className="text-sm text-gray-600">{event.address}</div>
-              {/* Add more event details as needed */}
             </li>
           ))}
         </ol>

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -10,7 +10,7 @@
  */
 import { useParams } from "react-router-dom";
 import React, { useEffect, useState } from "react";
-import { getPlanById } from "../../api";
+import { getPlanById, getEventById } from "../../api";
 import { APIProvider, Map } from "@vis.gl/react-google-maps";
 import Route from "./Route";
 import Layout from "../Layout/Layout";
@@ -19,12 +19,23 @@ import UserLocationMarker from "../MapComponent/UserLocationMarker";
 export default function PlanViewer() {
   const { planId } = useParams();
   const [plan, setPlan] = useState(null);
+  const [events, setEvents] = useState([]);
 
   useEffect(() => {
     getPlanById(planId)
       .then(setPlan)
       .catch(() => alert("Failed to load plan"));
   }, [planId]);
+
+  // Fetch events when plan is loaded
+  useEffect(() => {
+    if (plan && plan.event_ids && plan.event_ids.length > 0) {
+      Promise.all(plan.event_ids.map((id) => getEventById(id)))
+        .then(setEvents)
+        .catch(() => alert("Failed to load events"));
+        console.log("Events fetched:", events);
+    }
+  }, [plan]);
 
   if (!plan) return <div>Loading...</div>;
 


### PR DESCRIPTION
## Description

This PR implements tag preference to user plan creation. Users can select a tag that they would like to engage in during their plan, and they will have more time for these events in their plan. They can also now view a list of the events that are in their plan in the view event page, as well as the duration at each event. 

Next step will be to add some more styling and optimization to this feature.

## Milestones

This is another iteration on TC2.

## Test Plan

I tested this code with null inputs and have comprehensive error handling and checks for tag selection and event generation.
Here are two images of the new UI changes:

<img width="1212" height="1357" alt="Screenshot 2025-07-17 at 8 56 54 PM" src="https://github.com/user-attachments/assets/f7e95639-c49d-4294-9ea2-58c41ab7cb88" />

<img width="1210" height="1353" alt="Screenshot 2025-07-17 at 8 57 10 PM" src="https://github.com/user-attachments/assets/e93516db-6280-4ae0-978c-4a69ae567b20" />


