### PR TITLE
Added plan shuffle 

### DIFF
--- a/src/backend/src/controllers/eventController.js
+++ b/src/backend/src/controllers/eventController.js
@@ -285,6 +285,8 @@ async function fetchEventsWithinPolygon(polygon) {
   }
 }
 
+exports.fetchEventsWithinPolygon = fetchEventsWithinPolygon;
+
 exports.getEventsWithinRadius = async (req, res) => {
   const { latitude, longitude, radius } = req.body;
 
@@ -401,3 +403,5 @@ async function fetchOptimalRoute(start, events, transportType) {
   }
   return response.json();
 }
+
+exports.fetchOptimalRoute = fetchOptimalRoute;

--- a/src/backend/src/controllers/eventController.js
+++ b/src/backend/src/controllers/eventController.js
@@ -353,6 +353,7 @@ exports.getOptimalRoute = async (req, res) => {
 };
 
 async function fetchOptimalRoute(start, events, transportType) {
+  console.log("Fetching optimal route with start:", start, "events:", events, "transportType:", transportType);
   const routeRequest = {
     origin: {
       location: {
@@ -396,6 +397,7 @@ async function fetchOptimalRoute(start, events, transportType) {
     },
     body: JSON.stringify(routeRequest),
   });
+  console.log("Route API response status:", response);
   if (!response.ok) {
     const errorText = await response.text();
     console.error("Failed to fetch route:", response.status, response.statusText, errorText);

--- a/src/backend/src/controllers/eventController.js
+++ b/src/backend/src/controllers/eventController.js
@@ -353,7 +353,6 @@ exports.getOptimalRoute = async (req, res) => {
 };
 
 async function fetchOptimalRoute(start, events, transportType) {
-  console.log("Fetching optimal route with start:", start, "events:", events, "transportType:", transportType);
   const routeRequest = {
     origin: {
       location: {
@@ -397,10 +396,8 @@ async function fetchOptimalRoute(start, events, transportType) {
     },
     body: JSON.stringify(routeRequest),
   });
-  console.log("Route API response status:", response);
   if (!response.ok) {
     const errorText = await response.text();
-    console.error("Failed to fetch route:", response.status, response.statusText, errorText);
     throw new Error("Failed to fetch route");
   }
   return response.json();

--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -817,10 +817,7 @@ exports.shufflePlan = async (req, res) => {
       endMs,
       plan.owner_id
     );
-    console.log(
-      `Generated plan with ${selectedIds.length} events for plan ${planId}`
-    );
-
+  
     const origin = tagSetsByUser.__originLoc;
     const waypoints = selectedIds
       .map((id) => {
@@ -854,7 +851,6 @@ exports.shufflePlan = async (req, res) => {
 
     res.json(updatedPlan);
   } catch (error) {
-    console.error("Error shuffling plan:", error);
     res.status(500).json({ error: `Failed to shuffle plan: ${error.message}` });
   }
 };

--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -631,3 +631,5 @@ exports.joinPlan = async (req, res) => {
     res.status(500).json({ error: `Failed to join plan: ${error.message}` });
   }
 };
+
+// exports.shufflePlan = async (req, res) => {

--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -728,6 +728,8 @@ function generateEventPlan(events, tagSetsByUser, startMs, endMs, creatorId) {
 }
 
 exports.shufflePlan = async (req, res) => {
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
   try {
     const planId = req.params.planId;
     const userId = req.params.id;

--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -632,4 +632,27 @@ exports.joinPlan = async (req, res) => {
   }
 };
 
-// exports.shufflePlan = async (req, res) => {
+ const computeDistanceKm = (locA, locB) => {
+    const R = 6371; // Radius of the Earth in km
+    const dLat = (locB.lat - locA.lat) * (Math.PI / 180);
+    const dLon = (locB.lng - locA.lng) * (Math.PI / 180);
+    const a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(locA.lat * (Math.PI / 180)) *
+        Math.cos(locB.lat * (Math.PI / 180)) *
+        Math.sin(dLon / 2) *
+        Math.sin(dLon / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return R * c; // Distance in km
+  };
+
+const computeTravelTimeMs = (locA, locB) => {
+    const distanceKm = computeDistanceKm(locA, locB);
+    const factor = distanceKm / 50; // Assuming average speed of 50 km/h
+    return factor * 60 * 60 * 1000; // Convert to milliseconds
+  };
+
+exports.shufflePlan = async (req, res) => {
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  
+} 

--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -502,7 +502,7 @@ exports.createPlan = async (req, res) => {
 
   try {
     const ownerId = req.params.id;
-    const { title, eventIds, routeData, durations } = req.body;
+    const { title, eventIds, routeData, durations, start, end, polygon } = req.body;
     const { data, error } = await supabase
       .from("plans")
       .insert([
@@ -527,7 +527,6 @@ exports.createPlan = async (req, res) => {
     }
     res.json(data);
   } catch (error) {
-    console.error("Error creating plan:", error);
     res.status(500).json({ error: `Failed to create plan: ${error.message}` });
   }
 };

--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -753,6 +753,34 @@ exports.shufflePlan = async (req, res) => {
 
     // load tags for participants
     const userIds = [plan.owner_id, ...(plan.participants || [])];
-    let {at}
+    let {data: users, error: ue} = await supabase
+      .from("User")
+      .select("id, tags(name). user_locations(location)")
+      .in("id", userIds);
+    if (ue) {
+      return res.status(500).json({ error: `Failed to fetch users: ${ue.message}` });
+    }
+    // build tag sets by user
+    const tagSetsByUser = {};
+    users.forEach((user) => {
+      tagSetsByUser[user.id] = new Set((user.tags || []).map((t) => t.name));
+      if (user.id == plan.owner_id && user.user_locations) {
+        const { latitude, longitude } = user.user_locations;
+        tagSetsByUser.__originLoc = {
+          lat: latitude,
+          lng: longitude,
+        };
   }
+}
+const {selectedIds, durations} = generateEventPlan(
+  events,
+  tagSetsByUser,
+  new Date(plan.start_time).getTime(),
+  new Date(plan.end_time).getTime(),
+  plan.owner_id
+);
+
+const route_data = await fetchOptimal
+  }
+
 };

--- a/src/backend/src/routes/userRoutes.js
+++ b/src/backend/src/routes/userRoutes.js
@@ -24,7 +24,9 @@ const {
   createPlan,
   inviteUsers,
   listInvitations,
-  getPlanById
+  getPlanById,
+  joinPlan,
+  shufflePlan
 } = require("../controllers/userController");
 
 const router = express.Router();
@@ -68,5 +70,7 @@ router.post("/:id/plans", createPlan); // Create a new plan
 router.post("/:id/plans/:planId/invite", inviteUsers); // Invite users to a plan
 router.get("/:id/invitations", listInvitations); // List invitations for the user
 router.get("/:id/plans/:planId", getPlanById); // Get a specific plan by ID
+router.post("/:id/plans/:planId/join", joinPlan); // Join a plan
+router.post("/:id/plans/:planId/shuffle", shufflePlan); // Shuffle a plan
 
 module.exports = router;

--- a/src/frontend/frontend/src/api.js
+++ b/src/frontend/frontend/src/api.js
@@ -391,14 +391,14 @@ export async function meUrl(path) {
   return `${URL}/users/${me}${path}`;
 }
 
-export async function createPlan({ title, eventIds, routeData, durations }) {
+export async function createPlan({ title, eventIds, routeData, durations, start, end, polygon }) {
   const url = await meUrl("/plans");
   const res = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ title, eventIds, routeData, durations }),
+    body: JSON.stringify({ title, eventIds, routeData, durations, start, end, polygon }),
     credentials: "include",
   });
   const response = await res.json();

--- a/src/frontend/frontend/src/api.js
+++ b/src/frontend/frontend/src/api.js
@@ -402,6 +402,7 @@ export async function createPlan({ title, eventIds, routeData, durations, start,
     credentials: "include",
   });
   const response = await res.json();
+  console.log("createPlan response:", response);
   if (!res.ok) {
     throw new Error(response.error || "Failed to create plan");
   }

--- a/src/frontend/frontend/src/api.js
+++ b/src/frontend/frontend/src/api.js
@@ -475,3 +475,35 @@ export async function getEventsWithinRadius({ lat, lng }, radius) {
   }
   return data;
 }
+
+export async function joinPlan(planId) {
+  const url = await meUrl(`/plans/${planId}/join`);
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+  const response = await res.json();
+  if (!res.ok) {
+    throw new Error(response.error || "Failed to join plan");
+  }
+  return response;
+}
+
+export async function shufflePlan(planId) {
+  const url = await meUrl(`/plans/${planId}/shuffle`);
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
+  const response = await res.json();
+  if (!res.ok) {
+    throw new Error(response.error || "Failed to shuffle plan");
+  }
+  return response;
+}

--- a/src/frontend/frontend/src/api.js
+++ b/src/frontend/frontend/src/api.js
@@ -402,7 +402,6 @@ export async function createPlan({ title, eventIds, routeData, durations, start,
     credentials: "include",
   });
   const response = await res.json();
-  console.log("createPlan response:", response);
   if (!res.ok) {
     throw new Error(response.error || "Failed to create plan");
   }

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -42,7 +42,6 @@ import {
 } from "../../api";
 import Route from "./Route";
 import UserLocationMarker from "../MapComponent/UserLocationMarker";
-import { pt } from "date-fns/locale";
 
 export default function MapPlan() {
   const [eventsInPoly, setEventsInPoly] = useState([]);

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -42,6 +42,7 @@ import {
 } from "../../api";
 import Route from "./Route";
 import UserLocationMarker from "../MapComponent/UserLocationMarker";
+import { pt } from "date-fns/locale";
 
 export default function MapPlan() {
   const [eventsInPoly, setEventsInPoly] = useState([]);
@@ -603,11 +604,19 @@ export default function MapPlan() {
               <Button
                 disabled={selectedFollowers.length === 0 || !planTitle.trim()}
                 onClick={async () => {
+                  
+                  const coords = drawnPolygon.current.getPath().getArray().map(pt => ({
+                    lat: pt.lat(),
+                    lng: pt.lng(),
+                  }));
                   const plan = await createPlan({
                     title: planTitle,
                     eventIds: selectedEventIds,
                     routeData: routeData,
                     durations: eventDurations,
+                    start: startDate,
+                    end: endDate,
+                    polygon: coords,
                   });
                   setPlanId(plan.id);
                   await inviteUsers(plan.id, selectedFollowers);

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -35,7 +35,7 @@ export default function PlanViewer() {
       const userId = await getSessionUserId();
       setHasJoined((p.participants || []).includes(userId));
     })();
-  }, [planId, plan]);
+  }, [planId]);
 
   const durations = plan?.durations || {};
 
@@ -84,6 +84,7 @@ export default function PlanViewer() {
                   const reshuffled = await shufflePlan(planId);
                   setPlan(reshuffled);
                   alert("Plan has been reshuffled!");
+                  window.location.reload(); // Reload to reflect changes
                 }}
               >
                 Reshuffle Plan

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -62,7 +62,32 @@ export default function PlanViewer() {
       <div className="map-plan-page relative w-full max-w-5xl mx-auto mt-10 bg-[var(--card)] text-[var(--card-foreground)] rounded-xl shadow-lg border border-[var(--border)] overflow-hidden h-auto">
         <div className="flex w-full bg-[var(--primary)] bg-opacity-90 text-[var(--primary-foreground)] py-6 px-8 z-10 rounded-t-xl shadow items-center justify-between">
           <div className="text-2xl font-bold tracking-wide flex-1 text-left">
-            {plan.title || "Plan Title"}
+            <h1>{plan.title || "Plan Title"}</h1>
+            {!hasJoined ? (
+              <button
+                className="btn-primary ml-4"
+                onClick={async () => {
+                  await joinPlan(planId);
+                  setHasJoined(true);
+                  const updated = await getPlanById(planId);
+                  setPlan(updated);
+                  alert("You have joined the plan!");
+                }}
+              >
+                Accept Invite
+              </button>
+            ) : (
+              <button
+                className="btn-secondary ml-4"
+                onClick={async () => {
+                  const reshuffled = await shufflePlan(planId);
+                  setPlan(reshuffled);
+                  alert("Plan has been reshuffled!");
+                }}
+              >
+                Reshuffle Plan
+              </button>
+            )}
           </div>
           <div className="flex-1 text-right">
             <h2 className="text-xl font-semibold mb-2">Stops on This Plan</h2>

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -35,7 +35,7 @@ export default function PlanViewer() {
       const userId = await getSessionUserId();
       setHasJoined((p.participants || []).includes(userId));
     })();
-  }, [planId]);
+  }, [planId, plan]);
 
   const durations = plan?.durations || {};
 

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -10,7 +10,12 @@
  */
 import { useParams } from "react-router-dom";
 import React, { useEffect, useState } from "react";
-import { getPlanById, getEventById } from "../../api";
+import {
+  getPlanById,
+  getEventById,
+  getSessionUserId,
+  joinPlan,
+} from "../../api";
 import { APIProvider, Map } from "@vis.gl/react-google-maps";
 import Route from "./Route";
 import Layout from "../Layout/Layout";
@@ -20,11 +25,15 @@ export default function PlanViewer() {
   const { planId } = useParams();
   const [plan, setPlan] = useState(null);
   const [events, setEvents] = useState([]);
+  const [hasJoined, setHasJoined] = useState(false);
 
   useEffect(() => {
-    getPlanById(planId)
-      .then(setPlan)
-      .catch(() => alert("Failed to load plan"));
+    (async () => {
+      const p = await getPlanById(planId);
+      setPlan(p);
+      const userId = await getSessionUserId();
+      setHasJoined((p.participants || []).includes(userId));
+    })();
   }, [planId]);
 
   const durations = plan?.durations || {};

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -15,6 +15,7 @@ import {
   getEventById,
   getSessionUserId,
   joinPlan,
+  shufflePlan,
 } from "../../api";
 import { APIProvider, Map } from "@vis.gl/react-google-maps";
 import Route from "./Route";


### PR DESCRIPTION
## Description

This PR adds support for users to accept invites to plans, and shuffle the events in the plan to fit their preferences. In this PR, I added endpoints to support joining plans, shuffling plans, and refactored routing and event generation to fit these together. After a user gets invited to a plan, they can accept the invitation on the view plan page, and optionally shuffle the events after they join. Shuffling the events takes into account the original event boundaries as defined by the plan creator, but alters the events to take into account the preferences of the newly joined user.

In the future I will add timing preferences so that users who join the plan will have the shuffled event time slots take into account the preferences of joined users, and the owner's preferences with different weights. I will also add styling to the reshuffling button, and more information as to what it does. I will also add the ability for the new route plan to populate on the view plan.

## Milestones

This is an iteration of TC2, and adds more interaction and functionality to the plan feature.

## Test Plan

Here is an image of before and after using the reshuffle button:

Before:
<img width="1038" height="1394" alt="Screenshot 2025-07-21 at 11 34 22 AM" src="https://github.com/user-attachments/assets/6d420cac-8a05-4a8f-bed2-1a4450527b18" />

After:

<img width="1038" height="1428" alt="Screenshot 2025-07-21 at 11 35 16 AM" src="https://github.com/user-attachments/assets/cf90f044-ee8c-4876-bc42-f49911629082" />

