### PR TITLE
Add dynamic timing and friendship logic to shuffle plan

### DIFF
--- a/src/backend/src/controllers/eventController.js
+++ b/src/backend/src/controllers/eventController.js
@@ -353,6 +353,7 @@ exports.getOptimalRoute = async (req, res) => {
 };
 
 async function fetchOptimalRoute(start, events, transportType) {
+
   const routeRequest = {
     origin: {
       location: {
@@ -396,11 +397,14 @@ async function fetchOptimalRoute(start, events, transportType) {
     },
     body: JSON.stringify(routeRequest),
   });
+  const json = await response.json();
+
+
   if (!response.ok) {
     const errorText = await response.text();
     throw new Error("Failed to fetch route");
   }
-  return response.json();
+  return json;
 }
 
 exports.fetchOptimalRoute = fetchOptimalRoute;

--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -817,8 +817,11 @@ exports.shufflePlan = async (req, res) => {
       endMs,
       plan.owner_id
     );
-  
-    const origin = tagSetsByUser.__originLoc;
+
+    const start = {
+      lat: tagSetsByUser.__originLoc.latitude,
+      lng: tagSetsByUser.__originLoc.longitude,
+    };
     const waypoints = selectedIds
       .map((id) => {
         const e = events.find((ev) => ev.id === id);
@@ -830,9 +833,8 @@ exports.shufflePlan = async (req, res) => {
       })
       .filter(Boolean);
 
-    const routeDataResp = await fetchOptimalRoute(origin, waypoints, "DRIVE");
+    const routeDataResp = await fetchOptimalRoute(start, waypoints, "DRIVE");
     const routeData = await routeDataResp.routes?.[0];
-
 
     let { data: updatedPlan, error: updateError } = await supabase
       .from("plans")

--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -843,6 +843,10 @@ exports.shufflePlan = async (req, res) => {
       plan.owner_id
     );
 
+    if(selectedIds.length === 0) {
+      return res.status(400).json({ error: "No suitable events found for the plan." });
+    }
+
     const start = {
       lat: tagSetsByUser.__originLoc.latitude,
       lng: tagSetsByUser.__originLoc.longitude,

--- a/src/frontend/frontend/components/ui/hover-card.jsx
+++ b/src/frontend/frontend/components/ui/hover-card.jsx
@@ -1,0 +1,39 @@
+import * as React from "react"
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+
+import { cn } from "../../lib/utils"
+
+function HoverCard({
+  ...props
+}) {
+  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
+}
+
+function HoverCardTrigger({
+  ...props
+}) {
+  return (<HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />);
+}
+
+function HoverCardContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}) {
+  return (
+    <HoverCardPrimitive.Portal data-slot="hover-card-portal">
+      <HoverCardPrimitive.Content
+        data-slot="hover-card-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props} />
+    </HoverCardPrimitive.Portal>
+  );
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/src/frontend/frontend/package-lock.json
+++ b/src/frontend/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-hover-card": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-navigation-menu": "^1.2.13",
         "@radix-ui/react-popover": "^1.1.14",
@@ -1270,6 +1271,37 @@
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.14.tgz",
+      "integrity": "sha512-CPYZ24Mhirm+g6D8jArmLzjYu4Eyg3TTUHswR26QgzXBHBe64BO/RHOJKzmF/Dxb4y4f9PKyJdwm/O/AhNkb+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-popper": "1.2.7",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/src/frontend/frontend/package.json
+++ b/src/frontend/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-hover-card": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-navigation-menu": "^1.2.13",
     "@radix-ui/react-popover": "^1.1.14",

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -225,108 +225,110 @@ export default function MapPlan() {
 
   /**
    * This function generates an event plan based on the selected area and time period.
-   * It filters the events found within the drawn polygon based on the user's selected time period.
-   * It then selects events that can be attended for a full hour, considering travel time.
-   * The function prioritizes events based on the user's tags and the time they can be attended
-   * before they end.
+   * It filters events based on the user's selected criteria, computes travel times,
+   * and dynamically assigns durations to each event based on their tag scores.
+   * The function ensures that the selected events fit within the user's availability
+   * and the event's time constraints.
+   * If no events are found or if the user hasn't selected a time period, it alerts
+   * the user accordingly.
    *
    * @returns {void}
    */
-  const generateEventPlan = () => {
-    if (!filterStart || !filterEnd) {
-      alert("Please select a time period for the events.");
-      return;
-    }
-    let durations = {};
+const generateEventPlan = () => {
+  if (!filterStart || !filterEnd) {
+    alert("Please select a time period for the events.");
+    return;
+  }
+  let durations = {};
 
-    const eventsToGenerate = filteredEvents
-      .slice() // copy array
-      .sort((a, b) => new Date(a.startTime) - new Date(b.startTime));
+  const eventsToGenerate = filteredEvents
+    .slice()
+    .sort((a, b) => new Date(a.startTime) - new Date(b.startTime));
 
-    if (eventsToGenerate.length === 0) {
-      alert("No events found in the selected area/time period.");
-      return;
-    }
+  if (eventsToGenerate.length === 0) {
+    alert("No events found in the selected area/time period.");
+    return;
+  }
 
-    const usedIds = new Set();
-    const picks = [];
-    let curTime = filterStart.getTime();
-    let curLoc = {
-      lat: userData?.location?.latitude,
-      lng: userData?.location?.longitude,
-    };
-
-    const MIN_DURATION = 30 * 60 * 1000; // 30 min
-    const MAX_DURATION = 2 * 60 * 60 * 1000; // 2 hours
-
-    while (true) {
-      if( curTime >= filterEnd.getTime() ) {
-        break; // No more time left to attend events
-      }
-      const candidates = eventsToGenerate.filter((e) => !usedIds.has(e.id));
-      if (candidates.length === 0) {
-        break;
-      }
-
-      const possibleEvents = candidates
-        .map((e) => {
-          const eventStartMs = new Date(e.startTime).getTime();
-          const eventEndMs = new Date(e.endTime).getTime();
-          const travelTimeMs = computeTravelTimeMs(curLoc, {
-            lat: e.location?.latitude,
-            lng: e.location?.longitude,
-          });
-          const arriveAt = Math.max(eventStartMs, curTime + travelTimeMs);
-          return { ...e, arriveAt, eventEndMs };
-        })
-        // Only keep events that can be attended for at least MIN_DURATION
-        .filter(
-          (e) =>
-            e.arriveAt + MIN_DURATION <=
-            Math.min(e.eventEndMs, filterEnd.getTime())
-        );
-
-      if (!possibleEvents || possibleEvents.length === 0) {
-        break;
-      }
-
-      const scores = possibleEvents.map((e) => 
-        tagScore(e)
-      ); 
-
-      const maxScore = Math.max(...scores, 1); // Avoid division by zero
-
-
-      possibleEvents.sort((a, b) => {
-        const diff = tagScore(b) - tagScore(a);
-        return diff !== 0 ? diff : a.arriveAt - b.arriveAt;
-      });
-
-      const pick = possibleEvents[0];
-      const isPreferred =
-        preferredTag && (pick.tags || []).some((t) => t.name === preferredTag);
-      const durationMs = (isPreferred ? 90 : 60) * 60 * 1000; // 90 mins if preferred tag, else 60 mins
-      picks.push(pick.id);
-      durations[pick.id] = durationMs;
-      usedIds.add(pick.id);
-
-      curTime = pick.arriveAt + 60 * 60 * 1000; // 1 hour at event
-      curLoc = {
-        lat: pick.location?.latitude,
-        lng: pick.location?.longitude,
-      };
-    }
-
-    setSelectedEventIds(picks);
-    if (picks.length === 0) {
-      alert("No events could be selected based on your criteria.");
-      return;
-    }
-    alert(
-      `Generated plan with ${picks.length} events based on your criteria. You can now calculate the route.`
-    );
-    setEventDurations(durations);
+  const usedIds = new Set();
+  const picks = [];
+  let curTime = filterStart.getTime();
+  let curLoc = {
+    lat: userData?.location?.latitude,
+    lng: userData?.location?.longitude,
   };
+
+  const MIN_DURATION = 30 * 60 * 1000; // 30 min
+  const MAX_DURATION = 2 * 60 * 60 * 1000; // 2 hours
+
+  while (true) {
+    if (curTime >= filterEnd.getTime()) break;
+    const candidates = eventsToGenerate.filter((e) => !usedIds.has(e.id));
+    if (candidates.length === 0) break;
+
+    const possibleEvents = candidates
+      .map((e) => {
+        const eventStartMs = new Date(e.startTime).getTime();
+        const eventEndMs = new Date(e.endTime).getTime();
+        const travelTimeMs = computeTravelTimeMs(curLoc, {
+          lat: e.location?.latitude,
+          lng: e.location?.longitude,
+        });
+        const arriveAt = Math.max(eventStartMs, curTime + travelTimeMs);
+        return { ...e, arriveAt, eventEndMs };
+      })
+      .filter(
+        (e) =>
+          e.arriveAt + MIN_DURATION <=
+          Math.min(e.eventEndMs, filterEnd.getTime())
+      );
+
+    if (!possibleEvents || possibleEvents.length === 0) break;
+
+    // Compute tag scores for scaling
+    const scores = possibleEvents.map((e) => tagScore(e));
+    const maxScore = Math.max(...scores, 1); // Avoid division by zero
+
+    possibleEvents.sort((a, b) => {
+      const diff = tagScore(b) - tagScore(a);
+      return diff !== 0 ? diff : a.arriveAt - b.arriveAt;
+    });
+
+    const pick = possibleEvents[0];
+    usedIds.add(pick.id);
+    picks.push(pick.id);
+
+    // Dynamically set duration based on tag score
+    const score = tagScore(pick);
+    let duration =
+      MIN_DURATION + ((MAX_DURATION - MIN_DURATION) * score) / maxScore;
+
+    // Don't exceed event's end or plan's end
+    const latestPossibleEnd = Math.min(pick.eventEndMs, filterEnd.getTime());
+    if (pick.arriveAt + duration > latestPossibleEnd) {
+      duration = latestPossibleEnd - pick.arriveAt;
+    }
+    duration = Math.max(duration, MIN_DURATION);
+
+    durations[pick.id] = duration;
+
+    curTime = pick.arriveAt + duration;
+    curLoc = {
+      lat: pick.location?.latitude,
+      lng: pick.location?.longitude,
+    };
+  }
+
+  setSelectedEventIds(picks);
+  if (picks.length === 0) {
+    alert("No events could be selected based on your criteria.");
+    return;
+  }
+  alert(
+    `Generated plan with ${picks.length} events based on your criteria. You can now calculate the route.`
+  );
+  setEventDurations(durations);
+};
 
   const handleTempSelectEvent = (eventId) => {
     setTempSelectedEventIds((prev) =>

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -63,6 +63,18 @@ export default function MapPlan() {
   const [isTagDialogOpen, setIsTagDialogOpen] = useState(false);
   const [preferredTag, setPreferredTag] = useState("");
   const [eventDurations, setEventDurations] = useState({});
+  const [selectedDate, setSelectedDate] = useState("");
+  const [startTime, setStartTime] = useState("");
+  const [endTime, setEndTime] = useState("");
+
+  useEffect(() => {
+    if (selectedDate && startTime) {
+      setStartDate(`${selectedDate}T${startTime}`);
+    }
+    if (selectedDate && endTime) {
+      setEndDate(`${selectedDate}T${endTime}`);
+    }
+  }, [selectedDate, startTime, endTime]);
 
   const filterStart = startDate ? new Date(startDate) : null;
   const filterEnd = endDate ? new Date(endDate) : null;
@@ -278,7 +290,8 @@ export default function MapPlan() {
       });
 
       const pick = possibleEvents[0];
-      const isPreferred = preferredTag && (pick.tags || []).some(t=> t.name === preferredTag);
+      const isPreferred =
+        preferredTag && (pick.tags || []).some((t) => t.name === preferredTag);
       const durationMs = (isPreferred ? 90 : 60) * 60 * 1000; // 90 mins if preferred tag, else 60 mins
       picks.push(pick.id);
       durations[pick.id] = durationMs;
@@ -336,21 +349,32 @@ export default function MapPlan() {
         </p>
         <div className="flex gap-4 mb-4">
           <div>
-            <Label htmlFor="filter-start">Start</Label>
+            <Label htmlFor="filter-date">Date</Label>
             <Input
-              id="filter-start"
-              type="datetime-local"
-              value={startDate}
-              onChange={(e) => setStartDate(e.target.value)}
+              id="filter-date"
+              type="date"
+              value={selectedDate}
+              onChange={(e) => setSelectedDate(e.target.value)}
             />
           </div>
           <div>
-            <Label htmlFor="filter-end">End</Label>
+            <Label htmlFor="filter-start-time">Start Time</Label>
             <Input
-              id="filter-end"
-              type="datetime-local"
-              value={endDate}
-              onChange={(e) => setEndDate(e.target.value)}
+              id="filter-start-time"
+              type="time"
+              value={startTime}
+              onChange={(e) => setStartTime(e.target.value)}
+              disabled={!selectedDate}
+            />
+          </div>
+          <div>
+            <Label htmlFor="filter-end-time">End Time</Label>
+            <Input
+              id="filter-end-time"
+              type="time"
+              value={endTime}
+              onChange={(e) => setEndTime(e.target.value)}
+              disabled={!selectedDate}
             />
           </div>
         </div>
@@ -603,11 +627,13 @@ export default function MapPlan() {
               <Button
                 disabled={selectedFollowers.length === 0 || !planTitle.trim()}
                 onClick={async () => {
-                  
-                  const coords = drawnPolygon.current.getPath().getArray().map(pt => ({
-                    lat: pt.lat(),
-                    lng: pt.lng(),
-                  }));
+                  const coords = drawnPolygon.current
+                    .getPath()
+                    .getArray()
+                    .map((pt) => ({
+                      lat: pt.lat(),
+                      lng: pt.lng(),
+                    }));
                   const plan = await createPlan({
                     title: planTitle,
                     eventIds: selectedEventIds,

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -21,6 +21,8 @@ import { APIProvider, Map } from "@vis.gl/react-google-maps";
 import Route from "./Route";
 import Layout from "../Layout/Layout";
 import UserLocationMarker from "../MapComponent/UserLocationMarker";
+import { Button } from "../../../components/ui/button";
+
 
 export default function PlanViewer() {
   const { planId } = useParams();
@@ -78,8 +80,7 @@ export default function PlanViewer() {
                 Accept Invite
               </button>
             ) : (
-              <button
-                className="btn-secondary ml-4"
+              <Button variant="secondary"
                 onClick={async () => {
                   const reshuffled = await shufflePlan(planId);
                   setPlan(reshuffled);
@@ -87,8 +88,8 @@ export default function PlanViewer() {
                   window.location.reload(); // Reload to reflect changes
                 }}
               >
-                Reshuffle Plan
-              </button>
+                Shuffle Plan
+              </Button>
             )}
           </div>
           <div className="flex-1 text-right">

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -46,9 +46,6 @@ export default function PlanViewer() {
         .then(setEvents)
         .catch(() => alert("Failed to load events"));
     }
-    console.log("plan:", plan);
-    console.log("events:", events);
-    console.log("plan event ids:", plan?.event_ids);
   }, [plan]);
 
   const orderedEvents = React.useMemo(() => {

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -46,6 +46,9 @@ export default function PlanViewer() {
         .then(setEvents)
         .catch(() => alert("Failed to load events"));
     }
+    console.log("plan:", plan);
+    console.log("events:", events);
+    console.log("plan event ids:", plan?.event_ids);
   }, [plan]);
 
   const orderedEvents = React.useMemo(() => {

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -22,7 +22,11 @@ import Route from "./Route";
 import Layout from "../Layout/Layout";
 import UserLocationMarker from "../MapComponent/UserLocationMarker";
 import { Button } from "../../../components/ui/button";
-
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "../../../components/ui/hover-card";
 
 export default function PlanViewer() {
   const { planId } = useParams();
@@ -67,7 +71,8 @@ export default function PlanViewer() {
           <div className="text-2xl font-bold tracking-wide flex-1 text-left">
             <h1>{plan.title || "Plan Title"}</h1>
             {!hasJoined ? (
-              <button
+              <Button
+                variant="secondary"
                 className="btn-primary ml-4"
                 onClick={async () => {
                   await joinPlan(planId);
@@ -78,18 +83,29 @@ export default function PlanViewer() {
                 }}
               >
                 Accept Invite
-              </button>
-            ) : (
-              <Button variant="secondary"
-                onClick={async () => {
-                  const reshuffled = await shufflePlan(planId);
-                  setPlan(reshuffled);
-                  alert("Plan has been reshuffled!");
-                  window.location.reload(); // Reload to reflect changes
-                }}
-              >
-                Shuffle Plan
               </Button>
+            ) : (
+              <HoverCard>
+                <HoverCardTrigger asChild>
+                  <Button
+                    variant="secondary"
+                    onClick={async () => {
+                      const reshuffled = await shufflePlan(planId);
+                      setPlan(reshuffled);
+                      alert("Plan has been reshuffled!");
+                      window.location.reload(); // Reload to reflect changes
+                    }}
+                  >
+                    Shuffle Plan
+                  </Button>
+                </HoverCardTrigger>
+                <HoverCardContent className="w-64">
+                  <p className="text-sm">
+                    Regenerate the events in this plan based on your preferences
+                    as well as the preferences of the creator.
+                  </p>
+                </HoverCardContent>
+              </HoverCard>
             )}
           </div>
           <div className="flex-1 text-right">

--- a/src/frontend/frontend/src/components/MapPlanPage/Route.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/Route.jsx
@@ -45,6 +45,7 @@ const Route = ({ route, event_ids }) => {
       fetchEvents();
     }, [event_ids]);
   }
+
   const onMarkerClick = useCallback(
     (id, marker) => {
       if (id !== selectedId) {

--- a/src/frontend/frontend/src/components/ProfilePage/ProfilePage.jsx
+++ b/src/frontend/frontend/src/components/ProfilePage/ProfilePage.jsx
@@ -42,7 +42,6 @@ import {
 import { Input } from "../../../components/ui/input";
 import { Label } from "../../../components/ui/label";
 import { APIProvider } from "@vis.gl/react-google-maps";
-import { Tag } from "lucide-react";
 import InvitesList from "./InvitesList";
 
 export default function ProfilePage() {


### PR DESCRIPTION
## Description

This PR iterates on the event plan shuffling and plan generation. It adds dynamic time selection based on time in plan, preference scores across all participants, as well as giving preference to users more connected to other participants. This PR also adds styling to shuffling, adding new routes and improved buttons to the View Event page. Furthermore, it adds dynamic timing calculation to the frontend event generation when creating a plan.

Next steps will be adding logic for plan creation in weather, and other iterations as needed.

## Milestones
This PR is another iteration towards TC 2.

## Resources
For my hover component, I used the [shadcn](https://ui.shadcn.com/docs/components) component library.

## Test Plan

Here is a quick video showing the functionality of the feature:
![ScreenRecording2025-07-21at3 56 56PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/48de09c9-ab3d-4d31-b29f-b675cdeab7e6)
