### PR TITLE
Add travel times to plan view

### DIFF
--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -507,8 +507,16 @@ exports.createPlan = async (req, res) => {
 
   try {
     const ownerId = req.params.id;
-    const { title, eventIds, routeData, durations, start, end, polygon, driving_times } =
-      req.body;
+    const {
+      title,
+      eventIds,
+      routeData,
+      durations,
+      start,
+      end,
+      polygon,
+      driving_times,
+    } = req.body;
     const { data, error } = await supabase
       .from("plans")
       .insert([
@@ -946,7 +954,6 @@ exports.shufflePlan = async (req, res) => {
       .eq("id", planId)
       .single();
     if (updateError) {
-      console.error("Update error:", updateError);
       return res
         .status(500)
         .json({ error: `Failed to update plan: ${updateError.message}` });
@@ -954,7 +961,6 @@ exports.shufflePlan = async (req, res) => {
 
     res.json(updatedPlan);
   } catch (error) {
-    console.error("Shuffle error:", error);
     res.status(500).json({ error: `Failed to shuffle plan: ${error.message}` });
   }
 };

--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -710,6 +710,7 @@ function generateEventPlan(
   const used = new Set();
   const picks = [];
   const durations = {};
+  const drivingTimes = {};
   let curTime = startMs;
   let curLoc = tagSetsByUser.__originLoc;
 
@@ -756,6 +757,7 @@ function generateEventPlan(
           ...e,
           arriveAt: arrive,
           eventEndMs: new Date(e.endTime).getTime(),
+          travelTime: travel,
         };
       })
       // Only keep events that can be attended for at least MIN_DURATION before they end
@@ -802,12 +804,13 @@ function generateEventPlan(
     duration = Math.max(duration, MIN_DURATION);
 
     durations[pick.id] = duration;
+    drivingTimes[pick.id] = pick.travelTime;
 
     curTime = pick.arriveAt + duration;
     curLoc = pick.location;
   }
 
-  return { selectedIds: picks, durations };
+  return { selectedIds: picks, durations, drivingTimes };
 }
 
 exports.shufflePlan = async (req, res) => {

--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -901,7 +901,7 @@ exports.shufflePlan = async (req, res) => {
       );
     });
 
-    const { selectedIds, durations } = generateEventPlan(
+    const { selectedIds, durations, drivingTimes } = generateEventPlan(
       events,
       tagSetsByUser,
       startMs,
@@ -940,10 +940,12 @@ exports.shufflePlan = async (req, res) => {
         event_ids: selectedIds,
         durations: durations,
         route_data: routeData,
+        driving_times: drivingTimes,
       })
       .eq("id", planId)
       .single();
     if (updateError) {
+      console.error("Update error:", updateError);
       return res
         .status(500)
         .json({ error: `Failed to update plan: ${updateError.message}` });
@@ -951,6 +953,7 @@ exports.shufflePlan = async (req, res) => {
 
     res.json(updatedPlan);
   } catch (error) {
+    console.error("Shuffle error:", error);
     res.status(500).json({ error: `Failed to shuffle plan: ${error.message}` });
   }
 };

--- a/src/backend/src/controllers/userController.js
+++ b/src/backend/src/controllers/userController.js
@@ -507,7 +507,7 @@ exports.createPlan = async (req, res) => {
 
   try {
     const ownerId = req.params.id;
-    const { title, eventIds, routeData, durations, start, end, polygon } =
+    const { title, eventIds, routeData, durations, start, end, polygon, driving_times } =
       req.body;
     const { data, error } = await supabase
       .from("plans")
@@ -522,6 +522,7 @@ exports.createPlan = async (req, res) => {
           start_time: start,
           end_time: end,
           polygon: polygon,
+          driving_times: driving_times,
         },
       ])
       .select()

--- a/src/frontend/frontend/src/api.js
+++ b/src/frontend/frontend/src/api.js
@@ -399,7 +399,18 @@ export async function createPlan({
   start,
   end,
   polygon,
+  driving_times,
 }) {
+  console.log("Creating plan with data:", {
+    title,
+    eventIds,
+    routeData,
+    durations,
+    start,
+    end,
+    polygon,
+    driving_times,
+  });
   const url = await meUrl("/plans");
   const res = await fetch(url, {
     method: "POST",
@@ -414,6 +425,7 @@ export async function createPlan({
       start,
       end,
       polygon,
+      driving_times,
     }),
     credentials: "include",
   });

--- a/src/frontend/frontend/src/api.js
+++ b/src/frontend/frontend/src/api.js
@@ -401,16 +401,6 @@ export async function createPlan({
   polygon,
   driving_times,
 }) {
-  console.log("Creating plan with data:", {
-    title,
-    eventIds,
-    routeData,
-    durations,
-    start,
-    end,
-    polygon,
-    driving_times,
-  });
   const url = await meUrl("/plans");
   const res = await fetch(url, {
     method: "POST",

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -74,6 +74,7 @@ export default function MapPlan() {
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
   const [isWeatherBad, setIsWeatherBad] = useState(false);
+  const [eventDrivingTimes, setEventDrivingTimes] = useState({});
   const MIN_DURATION = 30 * 60 * 1000; // 30 min at event
   const MAX_DURATION = 2 * 60 * 60 * 1000; // 2 hours at event
   const MINUTES_TO_MS = 60 * 1000; // Convert minutes to milliseconds
@@ -394,6 +395,7 @@ export default function MapPlan() {
       duration = Math.max(duration, MIN_DURATION);
 
       durations[pick.id] = duration;
+      drivingTimes[pick.id] = pick.travelTimeMs;
 
       curTime = pick.arriveAt + duration;
       curLoc = {
@@ -403,6 +405,7 @@ export default function MapPlan() {
     }
 
     setSelectedEventIds(picks);
+    setEventDrivingTimes(drivingTimes);
     if (picks.length === 0) {
       alert("No events could be selected based on your criteria.");
       return;
@@ -752,6 +755,7 @@ export default function MapPlan() {
                     start: startDate,
                     end: endDate,
                     polygon: coords,
+                    driving_times: eventDrivingTimes,
                   });
                   setPlanId(plan.id);
                   await inviteUsers(plan.id, selectedFollowers);

--- a/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/MapPlan.jsx
@@ -320,6 +320,7 @@ export default function MapPlan() {
       return;
     }
     let durations = {};
+    let drivingTimes = {};
 
     const eventsToGenerate = filteredEvents
       .slice()
@@ -352,7 +353,7 @@ export default function MapPlan() {
             lng: e.location?.longitude,
           });
           const arriveAt = Math.max(eventStartMs, curTime + travelTimeMs);
-          return { ...e, arriveAt, eventEndMs };
+          return { ...e, arriveAt, eventEndMs, travelTimeMs };
         })
         .filter(
           (e) =>

--- a/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
+++ b/src/frontend/frontend/src/components/MapPlanPage/PlanViewer.jsx
@@ -44,6 +44,7 @@ export default function PlanViewer() {
   }, [planId]);
 
   const durations = plan?.durations || {};
+  const drivingTimes = plan?.driving_times || {};
 
   // Fetch events when plan is loaded
   useEffect(() => {
@@ -112,16 +113,34 @@ export default function PlanViewer() {
             <h2 className="text-xl font-semibold mb-2">Stops on This Plan</h2>
             <ul className="inline-block text-left max-h-48 overflow-y-auto pr-2">
               {(orderedEvents || []).map((event, idx) => {
-                const mins =
+                // For all but the last event, show driving time to the next event
+                const isLast = idx === orderedEvents.length - 1;
+                const nextEvent = orderedEvents[idx + 1];
+                const drivingTimeToNext =
+                  !isLast &&
+                  drivingTimes &&
+                  nextEvent &&
+                  drivingTimes[nextEvent.id]
+                    ? Math.round(drivingTimes[nextEvent.id] / 60000)
+                    : null;
+                const eventDuration =
                   durations && durations[event.id]
                     ? Math.round(durations[event.id] / 60000)
                     : 60;
                 return (
-                  <li key={event.id || idx} className="mb-1 flex items-center">
-                    <span className="font-bold mr-2">{idx + 1}.</span>
-                    <span className="font-bold">{event.title}</span>
-                    <span className="ml-2 text-sm">{mins} min</span>
-                  </li>
+                  <React.Fragment key={event.id || idx}>
+                    <li className="mb-1 flex items-center">
+                      <span className="font-bold mr-2">{idx + 1}.</span>
+                      <span className="font-bold">{event.title}</span>
+                      {/* Show driving time to next event, except for the last event */}
+                      {!isLast && drivingTimeToNext !== null && (
+                        <span className="ml-2 text-xs text-gray-500">
+                          ({drivingTimeToNext} min drive to next)
+                        </span>
+                      )}
+                      <span className="ml-2 text-sm">{eventDuration} min</span>
+                    </li>
+                  </React.Fragment>
                 );
               })}
             </ul>


### PR DESCRIPTION
## Description

This PR adds the display of driving times to events on the view event screen. When creating an event plan, driving times are now stored alongside durations at events, and will be populated on the view event screen. This is a small change, and adds important travel information to plans.

## Milestones

This is a feature addition to the view events page. It is a QOL update, and not a set milestone.

## Test Plan

Tested backend with Insomnia.

Here is an image of the new feature:

<img width="1163" height="1456" alt="Screenshot 2025-07-25 at 4 40 52 PM" src="https://github.com/user-attachments/assets/ae30aaa9-0224-49dd-b8e1-fbdb431e56fe" />

